### PR TITLE
feat: ability to specify custom ntfy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Battery Notifier is a simple Rust-based utility that monitors battery levels and sends notifications when the battery is low, critically low, or overcharged. It supports local notifications and optional push notifications via [ntfy.sh](https://ntfy.sh/).
 
 ## Features
+
 - Notifies when the battery is **low** (default: 20%)
 - Notifies when the battery is **critically low** (default: 10%)
 - Notifies when the battery is **overcharged** while plugged in (default: 80%)
@@ -14,12 +15,14 @@ Battery Notifier is a simple Rust-based utility that monitors battery levels and
 ## Installation
 
 ### Prerequisites
+
 - Rust (for building from source)
 - `canberra-gtk-play` (for playing notification sounds)
 - `libnotify` (for local notifications)
 - `curl` (for ntfy.sh support)
 
 ### Building from Source
+
 ```sh
 # Clone the repository
 git clone https://github.com/ardentkilnfire/battery-notifier.git
@@ -33,10 +36,13 @@ sudo mv target/release/battery-notifier /usr/local/bin/
 ```
 
 ### Reducing binary size
+
 To reduce the binary size, you can use `UPX`. UPX is a free, portable, extendable, high-performance executable packer. For more details on how to use UPX, please refer to its [GitHub repository](https://github.com/upx/upx).
 
 ## Configuration
+
 Battery Notifier uses a configuration file located at:
+
 ```
 ~/.config/battery-notifier/config.toml
 ```
@@ -44,6 +50,7 @@ Battery Notifier uses a configuration file located at:
 If this file does not exist, the application will generate a default configuration.
 
 ### Default Config (`config.toml`):
+
 ```toml
 # Battery threshold settings
 low_battery = 20
@@ -60,38 +67,49 @@ check_interval = 60  # Time in seconds between battery status checks (min: 1, ma
 
 # ntfy.sh settings (leave empty if not using ntfy)
 ntfy_topic = ""
+ntfy_server = "https://ntfy.sh"
 ```
 
 ## Usage
 
 ### Running Manually
+
 ```sh
 battery-notifier
 ```
 
 ### Running on Startup (Hyprland Example)
+
 Add this line to your `hyprland.conf`:
+
 ```ini
 exec-once = battery-notifier &
 ```
 
 ### Testing Notifications
+
 - Local notification test:
+
 ```sh
 battery-notifier --test
 ```
+
 - ntfy.sh test (requires `ntfy_topic` to be set in the config):
+
 ```sh
 battery-notifier --notify
 ```
 
 - Reset config to default:
+
 ```sh
 battery-notifier --reset
 ```
 
 ## License
+
 This project is licensed under the MIT License.
 
 ## Contributions
+
 Contributions and suggestions are welcome! Feel free to open an issue or submit a pull request.

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub sound_volume: u8,
     pub check_interval: u64,
     pub ntfy_topic: Option<String>,
+    pub ntfy_server: String,
 }
 
 impl Config {
@@ -40,6 +41,7 @@ impl Config {
             sound_volume: 100,
             check_interval: 60,
             ntfy_topic: None,
+            ntfy_server: "https://ntfy.sh".to_string(),
         }
     }
 
@@ -59,7 +61,8 @@ impl Config {
     check_interval = 60  # Time in seconds between battery status checks (min: 1, max: 300)
 
 # ntfy.sh settings (leave empty if not using ntfy)
-    ntfy_topic = ""
+	ntfy_topic = ""
+	ntfy_server = "https://ntfy.sh"
 "#;
 
         if let Err(e) = fs::create_dir_all(path.parent().unwrap()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,11 @@ fn main() {
 
         if args.contains(&"--notify".to_string()) {
             if let Some(topic) = &config.ntfy_topic {
-                send_noti_via_ntfy("This is a test ntfy notification.", topic);
+                send_noti_via_ntfy(
+                    "This is a test ntfy notification.",
+                    topic,
+                    &config.ntfy_server,
+                );
             } else {
                 eprintln!("No ntfy topic set in config.");
             }
@@ -52,7 +56,11 @@ fn main() {
                     &config,
                 );
                 if let Some(topic) = &config.ntfy_topic {
-                    send_noti_via_ntfy(&format!("Battery Low: {}% remaining.", capacity), topic);
+                    send_noti_via_ntfy(
+                        &format!("Battery Low: {}% remaining.", capacity),
+                        topic,
+                        &config.ntfy_server,
+                    );
                 }
                 notified_low = true;
             }
@@ -87,6 +95,7 @@ fn main() {
                     send_noti_via_ntfy(
                         &format!("Battery Overcharging: {}% charged.", capacity),
                         topic,
+                        &config.ntfy_server,
                     );
                 }
                 notified_overcharge = true;
@@ -148,9 +157,9 @@ fn send_notification(title: &str, message: &str, config: &Config) {
     }
 }
 
-fn send_noti_via_ntfy(message: &str, topic: &str) {
+fn send_noti_via_ntfy(message: &str, topic: &str, server: &str) {
     if !topic.is_empty() {
-        let ntfy_url = format!("https://ntfy.sh/{}", topic);
+        let ntfy_url = format!("{}/{}", server, topic);
         let result = Command::new("curl")
             .arg("-d")
             .arg(format!("{}", message))


### PR DESCRIPTION
I have added ability to specify your own ntfy server. I needed this because i have self-hosted the ntfy server. The new `ntfy_server` key in config file allows you to customize the server origin. By default it is set to `https://ntfy.sh`.