### PR TITLE
MacOS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ battery-notifier --reset
 
 # Execute a single check without continuous monitoring
 battery-notifier --dry-run
+
+# Run with verbose logging for debugging
+battery-notifier --verbose 2
 ```
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/faiface/beep v1.1.0
 	github.com/gen2brain/beeep v0.0.0-20240516210008-9c006672e7f4
 	golang.org/x/sys v0.33.0
+	howett.net/plist v1.0.1
 )
 
 require (
@@ -21,5 +22,4 @@ require (
 	golang.org/x/exp/shiny v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/image v0.27.0 // indirect
 	golang.org/x/mobile v0.0.0-20231127183840-76ac6878050a // indirect
-	howett.net/plist v1.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -21,4 +21,5 @@ require (
 	golang.org/x/exp/shiny v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/image v0.27.0 // indirect
 	golang.org/x/mobile v0.0.0-20231127183840-76ac6878050a // indirect
+	howett.net/plist v1.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/hajimehoshi/oto v0.7.1 h1:I7maFPz5MBCwiutOrz++DLdbr4rTzBsbBuV2VpgU9kk
 github.com/hajimehoshi/oto v0.7.1/go.mod h1:wovJ8WWMfFKvP587mhHgot/MBr4DnNy9m6EepeVGnos=
 github.com/icza/bitio v1.0.0/go.mod h1:0jGnlLAx8MKMr9VGnn/4YrvZiprkvBelsVIbA9Jjr9A=
 github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBDIWGCdTt54nHt6EeI639SmHycLYL7FkA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jfreymuth/oggvorbis v1.0.1/go.mod h1:NqS+K+UXKje0FUYUPosyQ+XTVvjmVjps1aEZH1sumIk=
 github.com/jfreymuth/vorbis v1.0.0/go.mod h1:8zy3lUAm9K/rJJk223RKy6vjCZTWC61NA2QD06bfOE0=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
@@ -55,3 +56,7 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
+howett.net/plist v1.0.1 h1:37GdZ8tP09Q35o9ych3ehygcsL+HqKSwzctveSlarvM=
+howett.net/plist v1.0.1/go.mod h1:lqaXoTrLY4hg8tnEzNru53gicrbv7rrk+2xJA/7hw9g=

--- a/internal/battery/reader.go
+++ b/internal/battery/reader.go
@@ -1,11 +1,15 @@
 package battery
 
+import "github.com/akryptic/battery-notifier/internal/logging"
+
 func ReadLevel() (int, error) {
+	logging.Trace("Reading battery level")
 	level, err := batteryLevel()
 	return int(level), err
 }
 
 func ReadStatus() (BatteryStatus, error) {
+	logging.Trace("Reading battery charging status")
 	status, err := isCharging()
 
 	if err != nil {
@@ -20,6 +24,7 @@ func ReadStatus() (BatteryStatus, error) {
 }
 
 func ReadBatteryState() (BatteryState, error) {
+	logging.Trace("Reading complete battery state")
 	level, err := ReadLevel()
 	if err != nil {
 		return BatteryState{}, err

--- a/internal/battery/reader_darwin.go
+++ b/internal/battery/reader_darwin.go
@@ -68,7 +68,9 @@ func batteryLevel() (uint8, error) {
 		return 0, ErrNoSystemBattery
 	}
 
-	return uint8(batts[0].CurrentCapacity / batts[0].MaxCapacity * 100), nil
+    cap := uint8(float64(batts[0].CurrentCapacity) / float64(batts[0].MaxCapacity) * 100)
+
+	return cap, nil
 }
 
 func isCharging() (bool, error) {

--- a/internal/battery/reader_darwin.go
+++ b/internal/battery/reader_darwin.go
@@ -1,0 +1,87 @@
+// go:build darwin
+
+// The code is partially modified version of the code from the following repository.
+// LINK: https://github.com/distatus/battery/blob/master/battery_darwin.go
+// Copyright (C) 2016-2017,2023 Karol 'Kenji Takahashi' Woźniak
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+// OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package battery
+
+import (
+	"os/exec"
+
+	plist "howett.net/plist"
+)
+
+type battery struct {
+	Voltage           int
+	CurrentCapacity   int `plist:"AppleRawCurrentCapacity"`
+	MaxCapacity       int `plist:"AppleRawMaxCapacity"`
+	DesignCapacity    int
+	Amperage          int64
+	FullyCharged      bool
+	IsCharging        bool
+	ExternalConnected bool
+}
+
+func readBatteries() ([]*battery, error) {
+	out, err := exec.Command("ioreg", "-n", "AppleSmartBattery", "-r", "-a").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	var data []*battery
+	if _, err = plist.Unmarshal(out, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func batteryLevel() (uint8, error) {
+	batts, err := readBatteries()
+	if err != nil {
+		return 0, err
+	}
+
+	if len(batts) == 0 {
+		return 0, ErrNoSystemBattery
+	}
+
+	return uint8(batts[0].CurrentCapacity / batts[0].MaxCapacity * 100), nil
+}
+
+func isCharging() (bool, error) {
+
+	batts, err := readBatteries()
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(batts) == 0 {
+		return false, ErrNoSystemBattery
+	}
+
+	return batts[0].IsCharging, nil
+}

--- a/internal/battery/reader_darwin.go
+++ b/internal/battery/reader_darwin.go
@@ -68,7 +68,7 @@ func batteryLevel() (uint8, error) {
 		return 0, ErrNoSystemBattery
 	}
 
-    cap := uint8(float64(batts[0].CurrentCapacity) / float64(batts[0].MaxCapacity) * 100)
+	cap := uint8(float64(batts[0].CurrentCapacity) / float64(batts[0].MaxCapacity) * 100)
 
 	return cap, nil
 }

--- a/internal/cli/parser.go
+++ b/internal/cli/parser.go
@@ -3,18 +3,21 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/akamensky/argparse"
 	"github.com/akryptic/battery-notifier/internal/config"
+	"github.com/akryptic/battery-notifier/internal/logging"
 )
 
 type Options struct {
-	Test       bool
-	Ntfy       bool
-	Reset      bool
-	Read       bool
-	DryRun     bool
-	ConfigPath string
+	Test         bool
+	Ntfy         bool
+	Reset        bool
+	Read         bool
+	DryRun       bool
+	ConfigPath   string
+	VerboseLevel int
 }
 
 func ParseArgs() (*Options, error) {
@@ -54,10 +57,31 @@ func ParseArgs() (*Options, error) {
 		},
 	})
 
+	verboseLevel := parser.Int("v", "verbose", &argparse.Options{
+		Required: false,
+		Help:     "Verbose logging level (0=quiet, 1=info, 2=debug, 3=trace)",
+		Default:  1,
+		Validate: func(args []string) error {
+			if len(args) > 0 {
+				levelString := args[0]
+				level, err := strconv.Atoi(levelString)
+				if err != nil {
+					return fmt.Errorf("verbose level must be an integer")
+				}
+				if level < 0 || level > 3 {
+					return fmt.Errorf("verbose level must be between 0 and 3")
+				}
+			}
+			return nil
+		},
+	})
+
 	err := parser.Parse(os.Args)
 	if err != nil {
 		return nil, err
 	}
+
+	logging.SetLevel(*verboseLevel)
 
 	// if config path was not passed, use the default path
 	if *configPath == "" {
@@ -69,14 +93,13 @@ func ParseArgs() (*Options, error) {
 		}
 	}
 
-	fmt.Printf("config path: %s\n", *configPath)
-
 	return &Options{
-		Test:       *testFlag,
-		Ntfy:       *ntfyFlag,
-		Reset:      *resetFlag,
-		Read:       *readFlag,
-		DryRun:     *dryRunFlag,
-		ConfigPath: *configPath,
+		Test:         *testFlag,
+		Ntfy:         *ntfyFlag,
+		Reset:        *resetFlag,
+		Read:         *readFlag,
+		DryRun:       *dryRunFlag,
+		ConfigPath:   *configPath,
+		VerboseLevel: *verboseLevel,
 	}, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+	"github.com/akryptic/battery-notifier/internal/logging"
 )
 
 type Config struct {
@@ -69,8 +70,11 @@ func (c *Config) Validate() string {
 
 func Load(path string) (config Config, err error) {
 
+	logging.Trace("Loading configuration from: %s", path)
+
 	// if config file doesn't exist, generate a default config and return
 	if _, err := os.Stat(path); os.IsNotExist(err) {
+		logging.Debug("Config file does not exist, generating default config at: %s", path)
 		config := GenerateDefaultConfig(path)
 		return config, nil
 	}
@@ -80,6 +84,7 @@ func Load(path string) (config Config, err error) {
 }
 
 func GetDefaultConfig() Config {
+	logging.Trace("Creating default configuration values")
 	return Config{
 		LowBattery:      20,
 		CriticalBattery: 10,
@@ -99,19 +104,25 @@ func GetDefaultConfig() Config {
 }
 
 func GenerateDefaultConfig(path string) Config {
+	logging.Trace("Generating default configuration at: %s", path)
+
 	config := GetDefaultConfig()
 
 	dir := filepath.Dir(path)
+
+	logging.Debug("Creating config directory: %s", dir)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		panic(err)
 	}
 
 	file, err := os.Create(path)
+	logging.Trace("Creating config file")
 	if err != nil {
 		panic(err)
 	}
 	defer file.Close()
 
+	logging.Trace("Writing default config to file")
 	err = toml.NewEncoder(file).Encode(config)
 	if err != nil {
 		panic(err)
@@ -122,9 +133,12 @@ func GenerateDefaultConfig(path string) Config {
 
 // cross-platform default path for the config file
 func GetDefaultConfigPath() (string, error) {
+	logging.Trace("Determining default config path")
+
 	userConfigDir, err := os.UserConfigDir()
 
 	if err != nil {
+		logging.Warn("Failed to get user config dir, falling back to HOME. Error: %v", err)
 		// fallback to HOME
 		userConfigDir = os.Getenv("HOME")
 		if userConfigDir == "" {
@@ -133,5 +147,9 @@ func GetDefaultConfigPath() (string, error) {
 		userConfigDir = filepath.Join(userConfigDir, ".config")
 	}
 
-	return filepath.Join(userConfigDir, "battery-notifier", "config.toml"), nil
+	configPath := filepath.Join(userConfigDir, "battery-notifier", "config.toml")
+
+	logging.Debug("Default config path determined: %s", configPath)
+
+	return configPath, nil
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,66 @@
+package logging
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+type LogLevel int
+
+const (
+	LevelQuiet LogLevel = iota
+	LevelInfo
+	LevelDebug
+	LevelTrace
+)
+
+var (
+	currentLevel LogLevel = LevelQuiet
+	logger       *log.Logger
+)
+
+func init() {
+	logger = log.New(os.Stdout, "", 0)
+}
+
+func SetLevel(level int) {
+	if level < 0 {
+		level = 0
+	}
+	if level > 3 {
+		level = 3
+	}
+	currentLevel = LogLevel(level)
+}
+
+func formatMessage(level string, msg string) string {
+	return fmt.Sprintf("[%s] [%s] %s", time.Now().Format("2006-01-02 15:04:05.000"), level, msg)
+}
+
+func Info(msg string, args ...interface{}) {
+	if currentLevel >= LevelInfo {
+		logger.Println(formatMessage("INFO", fmt.Sprintf(msg, args...)))
+	}
+}
+
+func Debug(msg string, args ...interface{}) {
+	if currentLevel >= LevelDebug {
+		logger.Println(formatMessage("DEBUG", fmt.Sprintf(msg, args...)))
+	}
+}
+
+func Trace(msg string, args ...interface{}) {
+	if currentLevel >= LevelTrace {
+		logger.Println(formatMessage("TRACE", fmt.Sprintf(msg, args...)))
+	}
+}
+
+func Error(msg string, args ...interface{}) {
+	logger.Println(formatMessage("ERROR", fmt.Sprintf(msg, args...)))
+}
+
+func Warn(msg string, args ...interface{}) {
+	logger.Println(formatMessage("WARN", fmt.Sprintf(msg, args...)))
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 )
 
@@ -36,7 +38,34 @@ func SetLevel(level int) {
 }
 
 func formatMessage(level string, msg string) string {
-	return fmt.Sprintf("[%s] [%s] %s", time.Now().Format("2006-01-02 15:04:05.000"), level, msg)
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+
+	// Base format with just timestamp and level
+	baseFormat := fmt.Sprintf("[%s] [%s]", timestamp, level)
+
+	// Add location info based on current log level
+	if currentLevel >= LevelDebug {
+		pc, file, line, ok := runtime.Caller(2)
+		if ok {
+			if currentLevel >= LevelTrace {
+				// Include file, line, and function name for TRACE level
+				funcName := runtime.FuncForPC(pc).Name()
+				// Extract just the function name (remove package path)
+				if lastSlash := filepath.Base(funcName); lastSlash != "" {
+					funcName = lastSlash
+				}
+				location := fmt.Sprintf("%s:%d:%s", filepath.Base(file), line, funcName)
+				return fmt.Sprintf("%s [%s] %s", baseFormat, location, msg)
+			} else {
+				// Include only file and line for DEBUG level
+				location := fmt.Sprintf("%s:%d", filepath.Base(file), line)
+				return fmt.Sprintf("%s [%s] %s", baseFormat, location, msg)
+			}
+		}
+	}
+
+	// For INFO level and below, just timestamp, level, and message
+	return fmt.Sprintf("%s %s", baseFormat, msg)
 }
 
 func Info(msg string, args ...interface{}) {

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -2,11 +2,11 @@ package monitor
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/akryptic/battery-notifier/internal/battery"
 	"github.com/akryptic/battery-notifier/internal/config"
+	"github.com/akryptic/battery-notifier/internal/logging"
 	"github.com/akryptic/battery-notifier/internal/notification"
 	"github.com/akryptic/battery-notifier/internal/sound"
 )
@@ -33,6 +33,8 @@ type Monitor struct {
 }
 
 func NewMonitor(conf *config.Config) *Monitor {
+	logging.Trace("Creating new monitor with config: LowBattery=%d, Critical=%d, Overcharge=%d",
+		conf.LowBattery, conf.CriticalBattery, conf.OverchargeLimit)
 	return &Monitor{
 		Config:        conf,
 		NotifiedState: &NotifiedState{false, false, false},
@@ -42,24 +44,24 @@ func NewMonitor(conf *config.Config) *Monitor {
 func (m *Monitor) determineRunType() (RunType, battery.BatteryState, error) {
 	batteryState, err := battery.ReadBatteryState()
 	if err != nil {
-		log.Printf("ERROR: Failed to read battery state: %v", err)
+		logging.Error("Failed to read battery state: %v", err)
 		return NoRun, batteryState, err
 	}
 
-	fmt.Printf("[%s] Battery: %d%% %s\n", time.Now().Format("2006-01-02 15:04:05"), batteryState.Level, batteryState.Status)
+	logging.Debug("Battery: %d%% %s", batteryState.Level, batteryState.Status)
 
 	if batteryState.Level <= m.Config.CriticalBattery && batteryState.Status != battery.Charging {
-		log.Printf("CRITICAL: Battery critically low (%d%% <= %d%%)", batteryState.Level, m.Config.CriticalBattery)
+		logging.Debug("CRITICAL: Battery critically low (%d%% <= %d%%)", batteryState.Level, m.Config.CriticalBattery)
 		return CriticalBatteryRun, batteryState, nil
 	}
 
 	if batteryState.Level <= m.Config.LowBattery && batteryState.Status != battery.Charging {
-		log.Printf("WARNING: Battery low (%d%% <= %d%%)", batteryState.Level, m.Config.LowBattery)
+		logging.Debug("LOW: Battery low (%d%% <= %d%%)", batteryState.Level, m.Config.LowBattery)
 		return LowBatteryRun, batteryState, nil
 	}
 
 	if batteryState.Level >= m.Config.OverchargeLimit && batteryState.Status == battery.Charging {
-		log.Printf("WARNING: Battery overcharging (%d%% >= %d%%)", batteryState.Level, m.Config.OverchargeLimit)
+		logging.Debug("OVERCHARGING: Battery overcharging (%d%% >= %d%%)", batteryState.Level, m.Config.OverchargeLimit)
 		return OverchargeLimitRun, batteryState, nil
 	}
 
@@ -68,103 +70,129 @@ func (m *Monitor) determineRunType() (RunType, battery.BatteryState, error) {
 
 // handles notification state and sending notifications
 func (m *Monitor) ProcessNotifications() (RunType, error) {
+
+	logging.Trace("Processing notifications")
+
 	runType, batteryState, err := m.determineRunType()
 
+	logging.Trace("Run: %s", runType)
+	logging.Trace("Battery state: %+v", batteryState)
+	logging.Trace("Notified state: %+v", m.NotifiedState)
+
 	if err != nil {
-		log.Printf("ERROR: Failed to determine run type: %v", err)
+		logging.Error("Failed to determine run type: %v", err)
 		return NoRun, err
 	}
 
 	if runType == NoRun {
+		logging.Trace("No notifications needed")
 		return NoRun, nil
 	}
 
-	if runType == LowBatteryRun && !m.NotifiedState.Low {
-		log.Printf("Sending low battery notification (%d%%)", batteryState.Level)
-		err := notification.SendNotification(
-			"Battery Low",
-			fmt.Sprintf("%d%% remaining. Please plug in.", batteryState.Level),
-			m.Config,
-		)
-		if err != nil {
-			log.Printf("ERROR: Failed to send low battery notification: %v", err)
-			return NoRun, err
-		}
-
-		if m.Config.EnableSound {
-			err := sound.Play("low", m.Config)
+	if runType == LowBatteryRun {
+		if !m.NotifiedState.Low {
+			logging.Debug("Sending low battery notification (%d%%)", batteryState.Level)
+			err := notification.SendNotification(
+				"Battery Low",
+				fmt.Sprintf("%d%% remaining. Please plug in.", batteryState.Level),
+				m.Config,
+			)
 			if err != nil {
-				log.Printf("WARNING: Failed to play low battery sound: %v", err)
-				// continue even if sound fails
+				logging.Error("Failed to send low battery notification: %v", err)
+				return NoRun, err
 			}
-		}
 
-		m.NotifiedState.Low = true
-		return LowBatteryRun, nil
+			if m.Config.EnableSound {
+				err := sound.Play("low", m.Config)
+				if err != nil {
+					logging.Warn("Failed to play low battery sound: %v", err)
+				}
+			}
+
+			m.NotifiedState.Low = true
+			return LowBatteryRun, nil
+		} else {
+			logging.Debug("Low Battery notification already sent, skipping")
+		}
 	}
 
 	if batteryState.Level > m.Config.LowBattery && m.NotifiedState.Low {
+		logging.Debug("Battery level recovered above low threshold (%d%% > %d%%), resetting low notification state",
+			batteryState.Level, m.Config.LowBattery)
 		m.NotifiedState.Low = false
 		return NoRun, nil
 	}
 
-	if runType == CriticalBatteryRun && !m.NotifiedState.Critical {
-		log.Printf("Sending critical battery notification (%d%%)", batteryState.Level)
-		err := notification.SendNotification(
-			"Battery Critically Low",
-			fmt.Sprintf("%d%% remaining! System may shut down.", batteryState.Level),
-			m.Config,
-		)
-		if err != nil {
-			log.Printf("ERROR: Failed to send critical battery notification: %v", err)
-			return NoRun, err
-		}
-
-		if m.Config.EnableSound {
-			err := sound.Play("low", m.Config)
+	if runType == CriticalBatteryRun {
+		if !m.NotifiedState.Critical {
+			logging.Debug("Sending critical battery notification (%d%%)", batteryState.Level)
+			err := notification.SendNotification(
+				"Battery Critically Low",
+				fmt.Sprintf("%d%% remaining! System may shut down.", batteryState.Level),
+				m.Config,
+			)
 			if err != nil {
-				log.Printf("WARNING: Failed to play critical battery sound: %v", err)
-				// continue even if sound fails
+				logging.Error("Failed to send critical battery notification: %v", err)
+				return NoRun, err
 			}
-		}
 
-		m.NotifiedState.Critical = true
-		return CriticalBatteryRun, nil
+			if m.Config.EnableSound {
+				err := sound.Play("low", m.Config)
+				if err != nil {
+					logging.Warn("Failed to play critical battery sound: %v", err)
+					// continue even if sound fails
+				}
+			}
+
+			m.NotifiedState.Critical = true
+			return CriticalBatteryRun, nil
+		} else {
+
+			logging.Debug("Critical Battery notification already sent, skipping")
+		}
 	}
 
 	if batteryState.Level > m.Config.CriticalBattery && m.NotifiedState.Critical {
+		logging.Debug("Battery level recovered above critical threshold (%d%% > %d%%), resetting critical notification state",
+			batteryState.Level, m.Config.CriticalBattery)
 		m.NotifiedState.Critical = false
 		return NoRun, nil
 	}
 
-	if runType == OverchargeLimitRun && !m.NotifiedState.Overcharge {
-		log.Printf("Sending overcharge notification (%d%%)", batteryState.Level)
-		err := notification.SendNotification(
-			"Battery Overcharging",
-			fmt.Sprintf(
-				"%d%% charged. Consider unplugging to preserve battery health.",
-				batteryState.Level,
-			),
-			m.Config,
-		)
-		if err != nil {
-			log.Printf("ERROR: Failed to send overcharge notification: %v", err)
-			return NoRun, nil
-		}
-
-		if m.Config.EnableSound {
-			err := sound.Play("overcharge", m.Config)
+	if runType == OverchargeLimitRun {
+		if !m.NotifiedState.Overcharge {
+			logging.Debug("Sending overcharge notification (%d%%)", batteryState.Level)
+			err := notification.SendNotification(
+				"Battery Overcharging",
+				fmt.Sprintf(
+					"%d%% charged. Consider unplugging to preserve battery health.",
+					batteryState.Level,
+				),
+				m.Config,
+			)
 			if err != nil {
-				log.Printf("WARNING: Failed to play overcharge sound: %v", err)
-				// continue even if sound fails
+				logging.Error("Failed to send overcharge notification: %v", err)
+				return NoRun, nil
 			}
-		}
 
-		m.NotifiedState.Overcharge = true
-		return OverchargeLimitRun, nil
+			if m.Config.EnableSound {
+				err := sound.Play("overcharge", m.Config)
+				if err != nil {
+					logging.Warn("Failed to play overcharge sound: %v", err)
+					// continue even if sound fails
+				}
+			}
+
+			m.NotifiedState.Overcharge = true
+			return OverchargeLimitRun, nil
+		} else {
+			logging.Debug("Overcharge notification already sent, skipping")
+		}
 	}
 
 	if batteryState.Level < m.Config.OverchargeLimit && m.NotifiedState.Overcharge {
+		logging.Debug("Battery level dropped below overcharge threshold (%d%% < %d%%), resetting overcharge notification state",
+			batteryState.Level, m.Config.OverchargeLimit)
 		m.NotifiedState.Overcharge = false
 		return NoRun, nil
 	}
@@ -174,27 +202,28 @@ func (m *Monitor) ProcessNotifications() (RunType, error) {
 
 // continuous monitoring of battery state
 func (m *Monitor) StartMonitoring() {
-	log.Printf("Starting battery monitoring with %d second intervals", m.Config.CheckInterval)
+	logging.Debug("Starting battery monitoring with %d second intervals", m.Config.CheckInterval)
 
 	for {
+		logging.Info("Running battery check")
 		runType, err := m.ProcessNotifications()
 		if err != nil {
-			log.Printf("ERROR: Monitoring failed: %v", err)
-			fmt.Println(err)
+			logging.Error("Monitoring failed: %v", err)
 			return
 		}
+		logging.Info("Run: %s", runType)
 
-		fmt.Printf("Run: %s\n", runType)
+		logging.Trace("Sleeping for %d seconds", m.Config.CheckInterval)
 		time.Sleep(time.Duration(m.Config.CheckInterval) * time.Second)
 	}
 }
 
 // dry-run
 func (m *Monitor) RunOnce() (RunType, error) {
-	log.Println("Running battery check (dry-run mode)")
+	logging.Info("Running battery check (dry-run mode)")
 	runType, err := m.ProcessNotifications()
 	if err != nil {
-		log.Printf("ERROR: Dry-run failed: %v", err)
+		logging.Error("Dry-run failed: %v", err)
 	}
 	return runType, err
 }

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -1,24 +1,27 @@
 package notification
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/akryptic/battery-notifier/internal/config"
+	"github.com/akryptic/battery-notifier/internal/logging"
 	"github.com/gen2brain/beeep"
 )
 
 func SendNotification(title, message string, config *config.Config) error {
+	logging.Debug("Sending notification: title='%s', message='%s'", title, message)
+
 	err := beeep.Notify(title, message, "")
 	if err != nil {
+		logging.Error("Failed to send local notification: %v", err)
 		return err
 	}
+
+	logging.Debug("Local notification sent successfully")
 
 	if config.NtfyTopic != "" {
 		ntfyErr := SendNtfyNotification(message, config.GetNtfyUrl(), config.NtfyAccessToken)
 
 		if ntfyErr != nil {
-			fmt.Fprintf(os.Stderr, "Failed to send ntfy notification: %v\n", ntfyErr)
+			logging.Error("Failed to send ntfy notification: %v", ntfyErr)
 		}
 	}
 

--- a/internal/notification/ntfy.go
+++ b/internal/notification/ntfy.go
@@ -3,31 +3,43 @@ package notification
 import (
 	"net/http"
 	"strings"
+
+	"github.com/akryptic/battery-notifier/internal/logging"
 )
 
 func SendNtfyNotification(message string, ntfyEndpoint string, ntfyAccessToken string) error {
+	logging.Debug("Sending ntfy notification")
+	logging.Trace("Ntfy message: '%s'", message)
+
 	if ntfyEndpoint == "" {
+		logging.Trace("Empty ntfy endpoint, skipping notification")
 		return nil
 	}
 
 	req, err := http.NewRequest("POST", ntfyEndpoint, strings.NewReader(message))
 
 	if err != nil {
+		logging.Error("Failed to create ntfy HTTP request: %v", err)
 		return err
 	}
 
 	// attach access token if provided
 	if ntfyAccessToken != "" {
+		logging.Trace("Adding authorization header to ntfy request")
 		req.Header.Set("Authorization", "Bearer "+ntfyAccessToken)
 	}
 
+	logging.Trace("Sending ntfy HTTP request")
 	resp, err := http.DefaultClient.Do(req)
 
 	if err != nil {
+		logging.Error("Failed to send ntfy HTTP request: %v", err)
 		return err
 	}
 
 	defer resp.Body.Close()
+
+	logging.Debug("Ntfy HTTP request completed with status: %d", resp.StatusCode)
 
 	return nil
 }

--- a/internal/sound/sound.go
+++ b/internal/sound/sound.go
@@ -5,13 +5,13 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/akryptic/battery-notifier/internal/config"
+	"github.com/akryptic/battery-notifier/internal/logging"
 	"github.com/faiface/beep"
 	"github.com/faiface/beep/effects"
 	"github.com/faiface/beep/mp3"
@@ -27,7 +27,10 @@ var (
 )
 
 func Play(soundType string, conf *config.Config) error {
+	logging.Trace("Playing sound: type='%s', volume=%d", soundType, conf.SoundVolume)
+
 	if !conf.EnableSound {
+		logging.Trace("Sound disabled in config, skipping playback")
 		return nil
 	}
 
@@ -36,10 +39,11 @@ func Play(soundType string, conf *config.Config) error {
 
 	switch soundType {
 	case "low":
+		logging.Trace("Loading low battery sound")
 		if conf.LowSoundFile != "" {
 			soundData, err = os.ReadFile(conf.LowSoundFile)
 			if err != nil {
-				log.Printf("ERROR: Failed to read custom low sound file '%s': %v", conf.LowSoundFile, err)
+				logging.Error("Failed to read custom low sound file '%s': %v", conf.LowSoundFile, err)
 				return fmt.Errorf("failed to read low sound file: %w", err)
 			}
 		} else {
@@ -49,20 +53,22 @@ func Play(soundType string, conf *config.Config) error {
 		if conf.OverchargeSoundFile != "" {
 			soundData, err = os.ReadFile(conf.OverchargeSoundFile)
 			if err != nil {
-				log.Printf("ERROR: Failed to read custom overcharge sound file '%s': %v", conf.OverchargeSoundFile, err)
+				logging.Error("Failed to read custom overcharge sound file '%s': %v", conf.OverchargeSoundFile, err)
 				return fmt.Errorf("failed to read overcharge sound file: %w", err)
 			}
 		} else {
 			soundData = overchargeDefaultSound
 		}
 	default:
-		log.Printf("ERROR: Invalid sound type requested: %s", soundType)
+		logging.Error("Invalid sound type requested: %s", soundType)
 		return fmt.Errorf("invalid sound type: %s", soundType)
 	}
 
+	logging.Trace("Sound data loaded, size: %d bytes", len(soundData))
+
 	err = playBytes(soundData, conf.SoundVolume)
 	if err != nil {
-		log.Printf("ERROR: Sound playback failed: %v", err)
+		logging.Error("Sound playback failed: %v", err)
 		return err
 	}
 
@@ -70,12 +76,15 @@ func Play(soundType string, conf *config.Config) error {
 }
 
 func playBytes(data []byte, vol int) error {
+
+	logging.Trace("Starting playback of %d bytes at volume %d", len(data), vol)
+
 	soundReader := bytes.NewReader(data)
 	closer := io.NopCloser(soundReader)
 
 	streamer, format, err := mp3.Decode(closer)
 	if err != nil {
-		log.Printf("ERROR: Failed to decode MP3 data: %v", err)
+		logging.Error("Failed to decode MP3 data: %v", err)
 		return fmt.Errorf("failed to decode sound file, ensure it's an MP3: %w", err)
 	}
 
@@ -83,11 +92,13 @@ func playBytes(data []byte, vol int) error {
 
 	err = initSpeakerWithTimeout(format)
 	if err != nil {
-		log.Printf("ERROR: Failed to initialize speaker: %v", err)
+		logging.Error("Failed to initialize speaker: %v", err)
 		return fmt.Errorf("audio system unavailable: %w", err)
 	}
 
 	volumeDB := userVolumeToDB(vol)
+
+	logging.Trace("Volume converted: %d%% -> %.2f dB", vol, volumeDB)
 
 	volumeControlledStreamer := &effects.Volume{
 		Streamer: streamer,
@@ -103,12 +114,13 @@ func playBytes(data []byte, vol int) error {
 		time.Sleep(10 * time.Second)
 		select {
 		case timeout <- true:
-			log.Println("WARNING: Audio playback timed out after 10 seconds")
 		default:
 		}
 	}()
 
+	logging.Trace("Clearing audio speaker")
 	speaker.Clear()
+	logging.Debug("Starting audio playback")
 	speaker.Play(beep.Seq(volumeControlledStreamer, beep.Callback(func() {
 		select {
 		case done <- true:
@@ -118,9 +130,12 @@ func playBytes(data []byte, vol int) error {
 
 	select {
 	case <-done:
+		speaker.Clear()
+		logging.Trace("Audio playback completed")
 		return nil
 	case <-timeout:
-		log.Println("WARNING: Sound playback timed out - likely running without audio session")
+		logging.Warn("Sound playback timed out - likely running without audio session")
+		logging.Trace("Clearing audio speaker")
 		speaker.Clear()
 		return fmt.Errorf("audio playback timed out - no audio session available")
 	}
@@ -130,6 +145,7 @@ var speakerInitOnce sync.Once
 var speakerInitError error
 
 func initSpeakerWithTimeout(format beep.Format) error {
+	logging.Trace("Initializing speaker (first time)")
 	speakerInitOnce.Do(func() {
 		done := make(chan bool, 1)
 		timeout := make(chan bool, 1)
@@ -145,7 +161,7 @@ func initSpeakerWithTimeout(format beep.Format) error {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					log.Printf("ERROR: Speaker initialization failed: %v", r)
+					logging.Error("Speaker initialization failed: %v", r)
 					speakerInitError = fmt.Errorf("speaker initialization failed: %v", r)
 				}
 				select {
@@ -154,14 +170,16 @@ func initSpeakerWithTimeout(format beep.Format) error {
 				}
 			}()
 
+			logging.Trace("Calling speaker.Init with sample rate: %d", format.SampleRate)
 			speaker.Init(format.SampleRate, format.SampleRate.N(time.Second/10))
 		}()
 
 		select {
 		case <-done:
 			// initialization completed (successfully or with panic)
+			logging.Trace("Speaker.Init completed successfully or with panic")
 		case <-timeout:
-			log.Println("ERROR: Speaker initialization timed out")
+			logging.Error("Speaker initialization timed out")
 			speakerInitError = fmt.Errorf("speaker initialization timed out")
 		}
 	})

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/akryptic/battery-notifier/internal/battery"
 	"github.com/akryptic/battery-notifier/internal/cli"
 	"github.com/akryptic/battery-notifier/internal/config"
+	"github.com/akryptic/battery-notifier/internal/logging"
 	"github.com/akryptic/battery-notifier/internal/monitor"
 	"github.com/akryptic/battery-notifier/internal/notification"
 	"github.com/akryptic/battery-notifier/internal/sound"
@@ -18,66 +19,82 @@ func main() {
 		return
 	}
 
+	logging.Info("Starting battery-notifier with verbose level %d", opts.VerboseLevel)
+
+	logging.Debug("Parsed args: %+v", opts)
+
 	// --reset
 	if opts.Reset {
+		logging.Trace("Detected --reset flag")
 		config.GenerateDefaultConfig(opts.ConfigPath)
 		return
 	}
 
 	// --read
 	if opts.Read {
+		logging.Trace("Detected --read flag")
+
 		state, err := battery.ReadBatteryState()
 
 		if err != nil {
-			fmt.Println(err)
+			logging.Error("Failed to read battery state: %v", err)
 			return
 		}
 
-		fmt.Printf("Status: %s\n", state.Status)
-		fmt.Printf("Level: %d%%\n", state.Level)
+		logging.Info("Status: %s", state.Status)
+		logging.Info("Level: %d%%", state.Level)
 		return
 	}
 
 	conf, err := config.Load(opts.ConfigPath)
 	if err != nil {
-		fmt.Println(err)
+		logging.Error("Failed to load config: %v", err)
 		return
 	}
 
 	validationError := conf.Validate()
 	if validationError != "" {
-		fmt.Println(validationError)
+		logging.Error("Failed to validate config: %s", validationError)
 		return
 	}
 
 	// --ntfy
 	if opts.Ntfy {
+		logging.Trace("Detected --ntfy flag")
+
 		if conf.NtfyTopic == "" {
-			fmt.Println("No ntfy topic set in config.")
+			logging.Error("No ntfy topic set in config.")
 			return
 		}
 
 		err := notification.SendNtfyNotification("This is a test notification.", conf.GetNtfyUrl(), conf.NtfyAccessToken)
 		if err != nil {
-			fmt.Println(err)
+			logging.Error("Failed to send ntfy notification: %v", err)
+			return
 		}
+
+		logging.Info("Test ntfy notification sent successfully")
 		return
 	}
 
 	// --test
 	if opts.Test {
+		logging.Trace("Detected --test flag")
+
 		conf.NtfyTopic = ""
 		err := notification.SendNotification("Battery Notifier Test", "This is a test notification.", &conf)
 		if err != nil {
-			fmt.Println(err)
+			logging.Error("Failed to send test notification: %v", err)
+			return
 		}
 
 		if conf.EnableSound {
 			err := sound.Play("low", &conf)
 			if err != nil {
-				fmt.Println(err)
+				logging.Error("Failed to play sound for test notification: %v", err)
 			}
 		}
+		logging.Info("Test notification sent successfully")
 		return
 	}
 
@@ -85,13 +102,15 @@ func main() {
 
 	// --dry-run
 	if opts.DryRun {
+		logging.Trace("Detected --dry-run flag")
+
 		runType, err := batteryMonitor.RunOnce()
 		if err != nil {
-			fmt.Println(err)
+			logging.Error("Dry run failed: %v", err)
 			return
 		}
 
-		fmt.Printf("Dry run: %s\n", runType)
+		logging.Info("Dry run: %s", runType)
 		return
 	}
 


### PR DESCRIPTION
I implemented `reader_darwin.go` in `battery` module to read the battery information in darwin based operating systems.

It uses `ioreg` to fetch the information about the battery. We parse the information from [`plist`](https://en.wikipedia.org/wiki/Property_list) format to a structure.

### others

- [x] cross-platform config file path (already handled by [GetDefaultConfigPath](https://github.com/akryptic/battery-notifier/blob/cec5774bc68156fa02fdc2e5308fcb63d7b4e447/internal/config/config.go#L124))
- [ ] testing